### PR TITLE
use the latest stable escodegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "escodegen": "~1.1.0",
+    "escodegen": "~1.3.3",
     "esprima-fb": "3001.1.0-dev-harmony-fb"
   },
   "devDependencies": {


### PR DESCRIPTION
While debugging a node-browserify error (https://github.com/substack/node-browserify/issues/789), I traced the error back to node-detective. Attempting to `npm install detective` fails on my machine due to an error in escodegen@1.1.0:

```
npm ERR! Failed to parse json
npm ERR! Unexpected end of input
npm ERR! File: /path/to/.npm/escodegen/1.1.0/package/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! System Darwin 13.2.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /path/to/node-detective
npm ERR! node -v v0.10.28
npm ERR! npm -v 1.4.14
npm ERR! file /path/to/.npm/escodegen/1.1.0/package/package.json
npm ERR! code EJSONPARSE
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /path/to/node-detective/npm-debug.log
npm ERR! not ok code 0
```

Using the latest stable version of escodegen resolves the issue.