### PR TITLE
Skip unreachable requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var aparse = require('acorn').parse;
+var booleanCondition = require('esmangle-evaluator').booleanCondition;
 var defined = require('defined');
 
 var requireRe = /\brequire\b/;
@@ -29,7 +30,7 @@ var traverse = function (node, cb) {
         });
     }
     else if (node && typeof node === 'object') {
-        cb(node);
+        if (cb(node) === false) return;
 
         Object.keys(node).forEach(function (key) {
             if (key === 'parent' || !node[key]) return;
@@ -44,6 +45,23 @@ var walk = function (src, opts, cb) {
     traverse(ast, cb);
 };
 
+var isUnreachable = function (node) {
+    var p = node.parent;
+    if (!p) return false;
+    if (p.type === 'LogicalExpression') {
+        if (p.right !== node) return false;
+        var leftEval = booleanCondition(p.left);
+        return (leftEval === true && p.operator === '||')
+            || (leftEval === false && p.operator === '&&');
+    }
+    if (p.type === 'IfStatement' || p.type === 'ConditionalExpression') {
+        var testEval = booleanCondition(p.test);
+        return (testEval === true && p.alternate === node)
+            || (testEval === false && p.consequent === node);
+    }
+    return false;
+};
+
 var exports = module.exports = function (src, opts) {
     return exports.find(src, opts).strings;
 };
@@ -53,6 +71,7 @@ exports.find = function (src, opts) {
     opts.parse = opts.parse || {};
     opts.parse.tolerant = true;
     
+    var unreachables = opts.unreachables === true;
     var word = opts.word === undefined ? 'require' : opts.word;
     if (typeof src !== 'string') src = String(src);
     src = src.replace(/^#![^\n]*\n/, '');
@@ -73,6 +92,7 @@ exports.find = function (src, opts) {
     if (!wordRe.test(src)) return modules;
     
     walk(src, opts.parse, function (node) {
+        if (!unreachables && isUnreachable(node)) return false;
         if (!isRequire(node)) return;
         if (node.arguments.length) {
             if (node.arguments[0].type === 'Literal') {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "acorn": "^1.0.3",
     "defined": "0.0.0",
-    "escodegen": "^1.4.1"
+    "escodegen": "^1.4.1",
+    "esmangle-evaluator": "^1.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.0"

--- a/readme.markdown
+++ b/readme.markdown
@@ -63,6 +63,7 @@ Optionally:
 * `opts.nodes` - when `true`, populate `found.nodes`
 * `opts.isRequire(node)` - a function returning whether an AST node is a require
 call
+* `opts.unreachables` - when `true`, include unreachable `require()` calls
 * `opts.parse` - supply options directly to
 [acorn](https://npmjs.org/package/acorn) with some support for esprima-style
 options `range` and `loc`

--- a/test/files/unreachable-conditional.js
+++ b/test/files/unreachable-conditional.js
@@ -1,0 +1,7 @@
+true ? require('1') : require('2');
+false ? require('3') : require('4');
+
+'production' !== 'development' ? require('5') : require('6');
+'development' !== 'development' ? require('7') : require('8');
+
+hello() ? require('9') : require('10');

--- a/test/files/unreachable-if.js
+++ b/test/files/unreachable-if.js
@@ -1,0 +1,53 @@
+if (true) {
+    require('1');
+} else {
+    require('2');
+}
+
+if (true) {
+    require('3');
+} else if (true) {
+    require('4');
+} else {
+    require('5');
+}
+
+if (false) {
+    require('6');
+} else {
+    require('7');
+}
+
+if (false) {
+    require('7');
+} else if (false) {
+    require('8');
+} else {
+    require('9');
+}
+
+if ('production' !== 'development') {
+    require('10');
+} else {
+    require('11');
+}
+
+if ('development' !== 'development') {
+    require('12');
+} else {
+    require('13');
+}
+
+if (hello()) {
+    require('14');
+} else {
+    require('15');
+}
+
+if (hello()) {
+    require('16');
+} else if (true) {
+    require('17');
+} else {
+    require('18');
+}

--- a/test/files/unreachable-logical.js
+++ b/test/files/unreachable-logical.js
@@ -1,0 +1,14 @@
+true && require('1');
+true || require('2');
+
+false && require('3');
+false || require('4');
+
+'production' !== 'development' && require('5');
+'production' !== 'development' || require('6');
+
+'development' !== 'development' && require('7');
+'development' !== 'development' || require('8');
+
+hello() && require('9');
+hello() || require('10');

--- a/test/nested.js
+++ b/test/nested.js
@@ -4,6 +4,11 @@ var fs = require('fs');
 var src = fs.readFileSync(__dirname + '/files/nested.js');
 
 test('nested', function (t) {
-    t.deepEqual(detective(src), [ 'a', 'b', 'c' ]);
+    t.deepEqual(detective(src), [ 'a', 'c' ]);
+    t.end();
+});
+
+test('nested with unreachables', function (t) {
+    t.deepEqual(detective(src, {unreachables: true}), [ 'a', 'b', 'c' ]);
     t.end();
 });

--- a/test/unreachable-conditional.js
+++ b/test/unreachable-conditional.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/unreachable-conditional.js');
+
+test('unreachable-conditional', function (t) {
+    t.plan(1);
+    t.deepEqual(detective(src), [ '1', '4', '5', '8', '9', '10' ]);
+});

--- a/test/unreachable-if.js
+++ b/test/unreachable-if.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/unreachable-if.js');
+
+test('unreachable-if', function (t) {
+    t.plan(1);
+    t.deepEqual(
+      detective(src),
+      [ '1', '3', '7', '9', '10', '13', '14', '15', '16', '17' ]);
+});

--- a/test/unreachable-logical.js
+++ b/test/unreachable-logical.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/unreachable-logical.js');
+
+test('unreachable-logical', function (t) {
+    t.plan(1);
+    t.deepEqual(detective(src), [ '1', '4', '5', '8', '9', '10' ]);
+});


### PR DESCRIPTION
This diff adds the ability to skip unreachable `require()` calls - it's turned on by default, but may be turned off by passing the `{unreachables: true}` option. This is originally from my [`unreachable-branch-transform`](https://github.com/zertosh/unreachable-branch-transform). However, for performance considerations and from a "this-is-how-it-should-work" perspective, it makes sense to have this functionality baked into `node-detective`.

"Unreachability" is determined by very basic static analysis of `if` statements, ternaries (`?`) and logical short-circuit evaluations (`||`/`&&`). `switch`s and `while`s are not analyzed. Only the operations that can be statically determined are considered - there is no guessing or heuristics - it's 100% safe. Once a code branch is determined to be unreachable, traversal of its children is aborted, but the rest continues.

Integrating with browserify:
browserify users should ideally have control over this option. browserify already passes options to module-deps, but module-deps [does not pass options](https://github.com/substack/module-deps/blob/574ed9a57cc637480a93b3072659cd5a0eca6435/index.js#L415) to detective. If this diff is merged. I'll submit the appropriate downstream PRs to address this.

The additional analysis logic has a negligible performance impact:
![bench](https://cloud.githubusercontent.com/assets/830952/6771626/c1d6be7e-d0b9-11e4-988e-d25ad879229a.png)

cc: @substack 