### PR TITLE
Update Travis CI tests to use newer Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - '0.10'
+  - '0.12'
+  - 'iojs'


### PR DESCRIPTION
As the `^1.4.1` syntax used for currently including the `escodegen` module was first introduced in npm `1.3`, the npm `1.2` verison included with node `0.8.x` fails at installing the dependency.

The `escodegen` module itself also in version `1.3.3` changed from requiring node `>=0.4.0` to requiring node `>=0.10.0`, so it explicitly doesn't support `0.8.x` anymore either.

The pull request to update the required `acorn` dependency ran into this issue and since that very same PR preferably should use the caret operator for the dependency it would be better to stop testing in node `0.8.x` and start testing in newer node versions instead.

Related PR: https://github.com/substack/node-detective/pull/41