### PR TITLE
Allow for parsing jsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ var defined = require('defined');
 
 function parse (src, opts) {
     if (!opts) opts = {};
+    var plugins = {};
+
+    if (opts.jsx) {
+        aparse = require('acorn-jsx').parse;
+        plugins.jsx = true;
+    }
+
     return aparse(src, {
         ecmaVersion: defined(opts.ecmaVersion, 6),
         ranges: defined(opts.ranges, opts.range),
@@ -12,7 +19,8 @@ function parse (src, opts) {
         ),
         strictSemicolons: defined(opts.strictSemicolons, false),
         allowTrailingCommas: defined(opts.allowTrailingCommas, true),
-        forbidReserved: defined(opts.forbidReserved, false)
+        forbidReserved: defined(opts.forbidReserved, false),
+        plugins: plugins
     });
 }
 var escodegen = require('escodegen');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "acorn": "^1.0.3",
+    "acorn-jsx": "^1.0.0",
     "defined": "0.0.0",
     "escodegen": "^1.4.1"
   },


### PR DESCRIPTION
Allow for parsing jsx files via `detective(src, { parse: { jsx: true } });`

I wasn't sure how to best document this, so I left it undocumented for now.