### PR TITLE
Optimization: Better word fast-path detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var aparse = require('acorn').parse;
 var defined = require('defined');
 
+var requireRe = /\brequire\b/;
+
 function parse (src, opts) {
     if (!opts) opts = {};
     return aparse(src, {
@@ -67,7 +69,8 @@ exports.find = function (src, opts) {
     var modules = { strings : [], expressions : [] };
     if (opts.nodes) modules.nodes = [];
     
-    if (src.indexOf(word) == -1) return modules;
+    var wordRe = word === 'require' ? requireRe : RegExp('\\b' + word + '\\b');
+    if (!wordRe.test(src)) return modules;
     
     walk(src, opts.parse, function (node) {
         if (!isRequire(node)) return;

--- a/test/complicated.js
+++ b/test/complicated.js
@@ -1,0 +1,56 @@
+var test = require('tap').test;
+var detective = require('../');
+
+var sources = [
+    'require("a")',
+    ';require("a")',
+    ' require("a")',
+    'void require("a")',
+    '+require("a")',
+    '!require("a")',
+    '/*comments*/require("a")',
+    '(require("a"))',
+
+    'require/*comments*/("a")',
+    ';require/*comments*/("a")',
+    ' require/*comments*/("a")',
+    'void require/*comments*/("a")',
+    '+require/*comments*/("a")',
+    '!require/*comments*/("a")',
+    '/*comments*/require/*comments*/("a")',
+    '(require/*comments*/("a"))',
+
+    'require /*comments*/ ("a")',
+    ';require /*comments*/ ("a")',
+    ' require /*comments*/ ("a")',
+    'void require /*comments*/ ("a")',
+    '+require /*comments*/ ("a")',
+    '!require /*comments*/ ("a")',
+    ' /*comments*/ require /*comments*/ ("a")',
+    '(require /*comments*/ ("a"))',
+
+    'require /*comments*/ /*more comments*/ ("a")',
+    ';require /*comments*/ /*more comments*/ ("a")',
+    ' require /*comments*/ /*more comments*/ ("a")',
+    'void require /*comments*/ /*more comments*/ ("a")',
+    '+require /*comments*/ /*more comments*/ ("a")',
+    '!require /*comments*/ /*more comments*/ ("a")',
+    ' /*comments*/ /*more comments*/ require /*comments*/ /*more comments*/ ("a")',
+    '(require /*comments*/ /*more comments*/ ("a"))',
+
+    'require//comments\n("a")',
+    ';require//comments\n("a")',
+    ' require//comments\n("a")',
+    'void require//comments\n("a")',
+    '+require//comments\n("a")',
+    '!require//comments\n("a")',
+    '  require//comments\n("a")',
+    '(require//comments\n("a"))'
+];
+
+test('complicated', function (t) {
+    t.plan(sources.length);
+    sources.forEach(function(src) {
+        t.deepEqual(detective(src), [ 'a' ]);
+    });
+});


### PR DESCRIPTION
Just doing an `indexOf` check could still match "requires", "required", "requirejs", etc. By using a conservative regexp we can decrease the likelihood of a false positive. (And I think a cached regexp is faster than `indexOf` http://jsperf.com/substring-test/3).

cc: @substack 

---
I had a better regexp for the common "require" case with no "isRequire" - which is why the test is so crazy. Let me know if you're open to it:

```
/(^|\W)require(\s*|\/\*[^*]*\*\/|\/\/[^\n]*)*\(/
   ^     ^    ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ^
   |     |    |                            |  |
   |     |    |                            |  + open parens 
   |     |    |                            v
   |     |    + (spaces | block comments | line comments) any number of times
   |   + our word
   + start or anything not [a-zA-Z_]
```