### PR TITLE
Use acorn's own traverser

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -61,8 +61,8 @@ Optionally:
 
 * `opts.word` - specify a different function name instead of `"require"`
 * `opts.nodes` - when `true`, populate `found.nodes`
-* `opts.isRequire(node)` - a function returning whether an AST node is a require
-call
+* `opts.isRequire(node)` - a function returning whether an AST `CallExpression`
+node is a require call
 * `opts.parse` - supply options directly to
 [acorn](https://npmjs.org/package/acorn) with some support for esprima-style
 options `range` and `loc`


### PR DESCRIPTION
Fixes https://github.com/substack/node-detective/pull/53.

Although we're now only visiting `CallExpression` nodes for the custom `isRequire` case, as opposed to all nodes, I'm not considering this a breaking change. There's been an implicit assumption that only `CallExpression` (and I guess `NewExpression`) nodes where being visited before this change. It's [assumed](https://github.com/substack/node-detective/blob/3f03dd4cf14e6d91a0eb9e322663065939fa73fe/index.js#L74) that any node that `isRequire` returns true for has an `arguments` object. Returning true for any other type of node, would've thrown since no other types have an `arguments` property.

Benchmark results:

```sh
# before
$ for i in {1..5}; do node bench/detect.js; done
140
132
143
125
133

# after
$ for i in {1..5}; do node bench/detect.js; done
100
105
105
105
106
```