### PR TITLE
remove escodegen and just grab the expr from the src

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var acorn = require('acorn');
 var walk = require('acorn/dist/walk');
-var escodegen = require('escodegen');
 var defined = require('defined');
 
 var requireRe = /\brequire\b/;
@@ -48,11 +47,12 @@ exports.find = function (src, opts) {
         CallExpression: function (node) {
             if (!isRequire(node)) return;
             if (node.arguments.length) {
-                if (node.arguments[0].type === 'Literal') {
-                    modules.strings.push(node.arguments[0].value);
+                var arg = node.arguments[0];
+                if (arg.type === 'Literal') {
+                    modules.strings.push(arg.value);
                 }
                 else {
-                    modules.expressions.push(escodegen.generate(node.arguments[0]));
+                    modules.expressions.push(src.slice(arg.start, arg.end));
                 }
             }
             if (opts.nodes) modules.nodes.push(node);

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "acorn": "^1.0.3",
-    "defined": "^1.0.0",
-    "escodegen": "^1.4.1"
+    "defined": "^1.0.0"
   },
   "devDependencies": {
     "tap": "^1.0.0"

--- a/test/files/both.js
+++ b/test/files/both.js
@@ -1,4 +1,4 @@
 require('a');
 require('b');
-require('c'+x);
-var moo = require('d'+y).moo;
+require('c' + x);
+var moo = require('d' + y).moo;


### PR DESCRIPTION
This bit is taken from https://github.com/substack/node-detective/pull/58. Besides loading faster and taking up less space, it should _help_  with https://github.com/eslint/eslint/pull/4307 and https://github.com/eslint/eslint/issues/3951