### PR TITLE
Add tests to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 bench/src/jquery.js
+/test


### PR DESCRIPTION
Tests take up space for nothing in the users node_modules, maybe we shouldn't ship them to npm ?