### PR TITLE
Update to Acorn v3 and tap v5. Closes GH-52

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "acorn": "^1.0.3",
+    "acorn": "^3.1.0",
     "defined": "^1.0.0"
   },
   "devDependencies": {
-    "tap": "^1.0.0"
+    "tap": "^5.7.1"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Update to Acorn v3 (and tap v5, since it had an older Acorn dependency). Closes GH-52

With this change, all tests pass