### PR TITLE
Add acorn options to parse.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ var requireRe = /\brequire\b/;
 
 function parse (src, opts) {
     if (!opts) opts = {};
-    return acorn.parse(src, {
+    var acornOpts = defined(opts.acorn, {});
+    var acornParser = defined(acornOpts.parser, acorn);
+    opts = Object.assign({}, {
         ecmaVersion: defined(opts.ecmaVersion, 6),
         sourceType: opts.sourceType,
         ranges: defined(opts.ranges, opts.range),
@@ -15,8 +17,9 @@ function parse (src, opts) {
         allowReturnOutsideFunction: defined(
             opts.allowReturnOutsideFunction, true
         ),
-        allowHashBang: defined(opts.allowHashBang, true)
-    });
+        allowHashBang: defined(opts.allowHashBang, true),
+    }, acornOpts.opts);
+    return acornParser.parse(src, opts);
 }
 
 var exports = module.exports = function (src, opts) {


### PR DESCRIPTION
This will allow module-deps to pass custom acorn options from browserify. I've tested it like:

```
let b = browserify({
        cache: {},
        debug: false,
        entries: './browser.js',
        detective: {
            acorn: {
                parser: acorn,
                opts: {
                    ecmaVersion: 7,
                    plugins: {
                        asyncawait: {
                            awaitAnywhere: true,
                        },
                    },
                },
            },
        },
    })
```